### PR TITLE
Rename the package to dev-oidc-provider

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],

--- a/.changeset/plain-otters-rename.md
+++ b/.changeset/plain-otters-rename.md
@@ -1,0 +1,13 @@
+---
+"dev-oidc-provider": major
+---
+
+Drop the `@comet` scope from the package name
+
+The package is now published as `dev-oidc-provider` instead of `@comet/dev-oidc-provider`.
+Update the dependency in your `package.json` and any imports accordingly:
+
+```diff
+-import { defineConfig } from "@comet/dev-oidc-provider";
++import { defineConfig } from "dev-oidc-provider";
+```

--- a/.changeset/plain-otters-rename.md
+++ b/.changeset/plain-otters-rename.md
@@ -2,9 +2,10 @@
 "dev-oidc-provider": major
 ---
 
-Drop the `@comet` scope from the package name
+Rename the package to `dev-oidc-provider`
 
-The package is now published as `dev-oidc-provider` instead of `@comet/dev-oidc-provider`.
+The `@comet` scope has been removed to make clear that the dev-oidc-provider can be used outside of Comet/Dextinity.
+
 Update the dependency in your `package.json` and any imports accordingly:
 
 ```diff

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Publish Canary release
         run: |
           echo --- > .changeset/canary.md
-          echo '"@comet/dev-oidc-provider": patch' >> .changeset/canary.md
+          echo '"dev-oidc-provider": patch' >> .changeset/canary.md
           echo --- >> .changeset/canary.md
           echo >> .changeset/canary.md
           echo fake change to always get a canary release >> .changeset/canary.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @comet/dev-oidc-provider
+# dev-oidc-provider
 
 ## 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# @comet/dev-oidc-provider
+# dev-oidc-provider
 
 This package can be used to spin up an OIDC provider for local development.
 
 ## Installation
 
-`npm i -D @comet/dev-oidc-provider`
+`npm i -D dev-oidc-provider`
 
 ## Create config file
 
@@ -13,7 +13,7 @@ The name must be dev-oidc-provider.config.mts and you have to place the working 
 Example:
 
 ```ts title="dev-oidc-provider.config.mts"
-import { defineConfig } from "@comet/dev-oidc-provider";
+import { defineConfig } from "dev-oidc-provider";
 
 export default defineConfig({
     userProvider: () => [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@comet/dev-oidc-provider",
+    "name": "dev-oidc-provider",
     "version": "1.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@comet/dev-oidc-provider",
+            "name": "dev-oidc-provider",
             "version": "1.2.1",
             "license": "BSD-2-Clause",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@comet/dev-oidc-provider",
+    "name": "dev-oidc-provider",
     "version": "1.2.1",
     "homepage": "https://github.com/vivid-planet/dev-oidc-provider#readme",
     "bugs": {
@@ -49,7 +49,6 @@
         "node": ">=22"
     },
     "publishConfig": {
-        "registry": "https://registry.npmjs.org",
-        "access": "public"
+        "registry": "https://registry.npmjs.org"
     }
 }


### PR DESCRIPTION
Remove the `@comet` scope to make clear that the dev-oidc-provider can be used outside of Comet/Dextinity.

https://claude.ai/code/session_01GgzvDg41acRDsUk4V5CziD