### PR TITLE
Remove Comet references from examples and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ export default defineConfig({
         {
             id: "1",
             name: "Admin",
-            email: "demo@comet-dxp.com",
+            email: "demo@example.com",
         },
         {
             id: "2",
             name: "Non-Admin",
-            email: "non-admin@comet-dxp.com",
+            email: "non-admin@example.com",
         },
     ],
     client: {
-        client_id: "comet-demo-client",
+        client_id: "demo-client",
         client_secret: "secret",
         redirect_uris: ["http://localhost:8000/oauth2/callback"],
         post_logout_redirect_uris: ["http://localhost:8000/oauth2/sign_out?rd=%2F"],

--- a/example/README.md
+++ b/example/README.md
@@ -6,6 +6,6 @@
 
 2. Start OIDC-Client (via Docker, make sure to have "Enable host networking" activated)
 
-    `docker run --rm -it --network="host" $(docker build -q .) --client-id comet-demo-client --client-secret secret`
+    `docker run --rm -it --network="host" $(docker build -q .) --client-id demo-client --client-secret secret`
 
 3. Open http://localhost:5555 in your browser to launch the OIDC-Client

--- a/example/dev-oidc-provider.config.mts
+++ b/example/dev-oidc-provider.config.mts
@@ -5,16 +5,16 @@ export default defineConfig({
         {
             id: "1",
             name: "Admin",
-            email: "demo@comet-dxp.com",
+            email: "demo@example.com",
         },
         {
             id: "2",
             name: "Non-Admin",
-            email: "non-admin@comet-dxp.com",
+            email: "non-admin@example.com",
         },
     ],
     client: {
-        client_id: "comet-demo-client",
+        client_id: "demo-client",
         client_secret: "secret",
         redirect_uris: ["http://localhost:5555/callback"],
     },


### PR DESCRIPTION
Instead of rebranding to Dextinity, I decided to use generic terms like `example.com`. This is in line with the decision to remove the `@comet` scope from the package, which makes clear that the dev-oidc-provider can be used outside of Comet/Dextinity (see https://github.com/vivid-planet/dev-oidc-provider/pull/95).

https://claude.ai/code/session_011miog3G3pdFDLLLh38Sf8w